### PR TITLE
fix: reset API versions to wip on main (fixes #21)

### DIFF
--- a/code/API_definitions/knowledge-base.yaml
+++ b/code/API_definitions/knowledge-base.yaml
@@ -45,7 +45,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -53,7 +53,7 @@ externalDocs:
   url: https://github.com/camaraproject/ModelAsAService
 
 servers:
-  - url: '{apiRoot}/knowledge-base/v0.1'
+  - url: '{apiRoot}/knowledge-base/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/qa-assistant-manage.yaml
+++ b/code/API_definitions/qa-assistant-manage.yaml
@@ -37,7 +37,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -45,7 +45,7 @@ externalDocs:
   url: https://github.com/camaraproject/ModelAsAService
 
 servers:
-  - url: '{apiRoot}/qa-assistant-manage/v0.1'
+  - url: '{apiRoot}/qa-assistant-manage/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/qa-assistant-service.yaml
+++ b/code/API_definitions/qa-assistant-service.yaml
@@ -36,7 +36,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -44,7 +44,7 @@ externalDocs:
   url: https://github.com/camaraproject/ModelAsAService
 
 servers:
-  - url: '{apiRoot}/qa-assistant-service/v0.1'
+  - url: '{apiRoot}/qa-assistant-service/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/knowledge-base.feature
+++ b/code/Test_definitions/knowledge-base.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA MaaS Knowledge base API, v0.1.0
+Feature: CAMARA MaaS Knowledge base API, vwip
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA MaaS Knowledge base API, v0.1.0
 
   Background: Common knowledge-base setup
     Given an environment at "apiRoot"
-    And the resource "/knowledge-base/v0.1/knowledge-bases"                                                              |
+    And the resource "/knowledge-base/vwip/knowledge-bases"                                                              |
 
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token

--- a/code/Test_definitions/qa-assistant-manage.feature
+++ b/code/Test_definitions/qa-assistant-manage.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA MaaS QA Assistant Management API, v0.1.0
+Feature: CAMARA MaaS QA Assistant Management API, vwip
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA MaaS QA Assistant Management API, v0.1.0
 
   Background: Common knowledge-base setup
     Given an environment at "apiRoot"
-    And the resource "/qa-assistant-manage/v0.1/assistants"                                                              |
+    And the resource "/qa-assistant-manage/vwip/assistants"                                                              |
 
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token

--- a/code/Test_definitions/qa-assistant-service.feature
+++ b/code/Test_definitions/qa-assistant-service.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA MaaS Q&A Assistant Service API, v0.1.0
+Feature: CAMARA MaaS Q&A Assistant Service API, vwip
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA MaaS Q&A Assistant Service API, v0.1.0
 
   Background: Common knowledge-base setup
     Given an environment at "apiRoot"
-    And the resource "/qa-assistant-service/v0.1/answer"                                                              |
+    And the resource "/qa-assistant-service/vwip/answer"                                                              |
 
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Resets API version information on `main` to `wip` after the previous release, per the standard CAMARA post-release procedure. Covers all three APIs in the repository.

This is a mandatory prerequisite for the Release Automation roll-out: the framework requires `wip` / `vwip` versions on `main` so the release process can drive transitions to concrete versions on dedicated release branches.

Six files updated, twelve lines:

- `code/API_definitions/qa-assistant-service.yaml`: `info.version` `0.1.0` → `wip`; server URL `v0.1` → `vwip`
- `code/API_definitions/qa-assistant-manage.yaml`: `info.version` `0.1.0` → `wip`; server URL `v0.1` → `vwip`
- `code/API_definitions/knowledge-base.yaml`: `info.version` `0.1.0` → `wip`; server URL `v0.1` → `vwip`
- `code/Test_definitions/qa-assistant-service.feature`: line 1 Feature header `v0.1.0` → `vwip`; line 14 resource URL `v0.1` → `vwip`
- `code/Test_definitions/qa-assistant-manage.feature`: line 1 Feature header `v0.1.0` → `vwip`; line 14 resource URL `v0.1` → `vwip`
- `code/Test_definitions/knowledge-base.feature`: line 1 Feature header `v0.1.0` → `vwip`; line 14 resource URL `v0.1` → `vwip`

#### Which issue(s) this PR fixes:

Fixes #21

#### Special notes for reviewers:

Mechanical wip reset across all three APIs. No semantic changes.

#### Changelog input

```
 release-note
Reset API versions on main to wip across qa-assistant-service, qa-assistant-manage and knowledge-base (post-release procedure).
```

#### Additional documentation

This section can be blank.

```
docs

```
